### PR TITLE
Ensure gopaths with trailing slashes still work

### DIFF
--- a/services/services.go
+++ b/services/services.go
@@ -82,7 +82,8 @@ func (s *Service) IsRunning() bool {
 // for the service.yml file. For every service it registers it after trying
 // to import the package using Go's build.Import package
 func DiscoverServices() {
-	buildPath := strings.Replace(ProjectPath, os.Getenv("GOPATH")+"/src/", "", 1)
+	gopath := strings.TrimRight(os.Getenv("GOPATH"), "/")
+	buildPath := strings.Replace(ProjectPath, gopath+"/src/", "", 1)
 	fd, _ := ioutil.ReadDir(ProjectPath)
 	for _, item := range fd {
 		serviceName := item.Name()


### PR DESCRIPTION
Otherwise you end up with an error importing every single service due to the double slash:

```
1429009093188507175 [Error] Error registering xxx
1429009093188522977 [Error] import "/home/jenkins/workspaces/xxx/src/github.com/xxx//xxx": cannot import absolute path
1429009093188557712 [Error] Error registering service.xxx
1429009093188565144 [Error] import "/home/jenkins/workspaces/xxx/src/github.com/xxx//service.xxx": cannot import absolute path
1429009093188577104 [Error] Error registering service.xxx
1429009093188580924 [Error] import "/home/jenkins/workspaces/xxx/src/github.com/xxx//service.xxx": cannot import absolute path
1429009093188598312 [Error] Error registering service.xxx
```
