### PR TITLE
Fix cli default config file path

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 
 var app *cli.App
 
+const defaultConfigFile = "orchestra.yml"
+
 func main() {
 	defer log.Flush()
 	app = cli.NewApp()
@@ -43,7 +45,12 @@ func main() {
 	// init checks for an existing orchestra.yml in the current working directory
 	// and creates a new .orchestra directory (if doesn't exist)
 	app.Before = func(c *cli.Context) error {
-		config.ConfigPath, _ = filepath.Abs(c.GlobalString("config"))
+		confVal := c.GlobalString("config")
+		if confVal == "" {
+			confVal = defaultConfigFile
+		}
+
+		config.ConfigPath, _ = filepath.Abs(confVal)
 		if _, err := os.Stat(config.ConfigPath); os.IsNotExist(err) {
 			fmt.Printf("No %s found. Have you specified the right directory?\n", c.GlobalString("config"))
 			os.Exit(1)


### PR DESCRIPTION
Due to an upstream change int the cli library the config value now appears blank rather than using the default value specified. I've had a cursory glace at the repo but can't see an obvious reason for this, so I've just set it to default if the string is blank. Should fix CI.
