### PR TITLE
Fix deadlock panics

### DIFF
--- a/commands/export.go
+++ b/commands/export.go
@@ -3,8 +3,8 @@ package commands
 import (
 	"fmt"
 
-	"github.com/mondough/orchestra/config"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/config"
 	"github.com/wsxiaoys/terminal"
 )
 

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 
 	"github.com/ActiveState/tail"
-	"github.com/mondough/orchestra/services"
 	log "github.com/cihub/seelog"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )
 
@@ -43,6 +43,7 @@ func ConsumeLogs() {
 }
 
 func TailServiceLog(service *services.Service, wg *sync.WaitGroup) {
+	defer wg.Done()
 	spacingLength := services.MaxServiceNameLength + 2 - len(service.Name)
 	t, err := tail.TailFile(service.LogFilePath, tail.Config{Follow: true})
 	if err != nil {
@@ -51,5 +52,4 @@ func TailServiceLog(service *services.Service, wg *sync.WaitGroup) {
 	for line := range t.Lines {
 		logReceiver <- fmt.Sprintf("@{%s}%s@{|}%s|  %s\n", service.Color, service.Name, strings.Repeat(" ", spacingLength), line.Text)
 	}
-	wg.Done()
 }

--- a/commands/ps.go
+++ b/commands/ps.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )
 

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )
 
@@ -40,6 +40,7 @@ func RestartAction(c *cli.Context) {
 }
 
 func restart(wg *sync.WaitGroup, c *cli.Context, service *services.Service) {
+	defer wg.Done()
 	spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
 
 	err := killService(service)
@@ -62,6 +63,4 @@ func restart(wg *sync.WaitGroup, c *cli.Context, service *services.Service) {
 	}
 
 	terminal.Stdout.Colorf("%s%s| @{c} %srestarted\n", service.Name, spacing, rebuiltStatus)
-
-	wg.Done()
 }

--- a/commands/start.go
+++ b/commands/start.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )
 
@@ -47,6 +47,7 @@ func StartAction(c *cli.Context) {
 }
 
 func start(wg *sync.WaitGroup, c *cli.Context, service *services.Service) {
+	defer wg.Done()
 	spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
 	if service.Process == nil {
 		rebuilt, err := buildAndStart(c, service)
@@ -63,7 +64,6 @@ func start(wg *sync.WaitGroup, c *cli.Context, service *services.Service) {
 	} else {
 		terminal.Stdout.Colorf("%s%s| @{c} already running\n", service.Name, spacing)
 	}
-	wg.Done()
 }
 
 // startService takes a Service struct as input, creates a new log file in .orchestra,

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )
 

--- a/commands/test.go
+++ b/commands/test.go
@@ -6,8 +6,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/mondough/orchestra/services"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
 	"github.com/wsxiaoys/terminal"
 )
 

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mondough/orchestra/config"
-	"github.com/mondough/orchestra/services"
 	log "github.com/cihub/seelog"
 	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/config"
+	"github.com/mondough/orchestra/services"
 )
 
 // This is temporary, very very alpha and may change soon

--- a/main.go
+++ b/main.go
@@ -6,11 +6,11 @@ import (
 	"path"
 	"path/filepath"
 
+	log "github.com/cihub/seelog"
+	"github.com/codegangsta/cli"
 	"github.com/mondough/orchestra/commands"
 	"github.com/mondough/orchestra/config"
 	"github.com/mondough/orchestra/services"
-	log "github.com/cihub/seelog"
-	"github.com/codegangsta/cli"
 )
 
 var app *cli.App


### PR DESCRIPTION
Make sure to call `wg.Done()` even when returning early, so there isn't a deadlock panic.
