### PR TITLE
Tweaks to ps output

### DIFF
--- a/commands/ps.go
+++ b/commands/ps.go
@@ -21,12 +21,13 @@ var PsCommand = &cli.Command{
 
 // PsAction checks the status for every service and output
 func PsAction(c *cli.Context) {
-	for name, service := range FilterServices(c) {
+	svcs := services.Sort(FilterServices(c))
+	for _, service := range svcs {
 		spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
 		if service.Process != nil {
-			terminal.Stdout.Colorf("@{g}%s", name).Reset().Colorf("%s|", spacing).Print(" running ").Colorf("  %d  %s\n", service.Process.Pid, getPorts(service))
+			terminal.Stdout.Colorf("@{g}%s", service.Name).Reset().Colorf("%s|", spacing).Print(" running ").Colorf("  %d  %s\n", service.Process.Pid, getPorts(service))
 		} else {
-			terminal.Stdout.Colorf("@{r}%s", name).Reset().Colorf("%s|", spacing).Reset().Print(" aborted\n")
+			terminal.Stdout.Colorf("@{r}%s", service.Name).Reset().Colorf("%s|", spacing).Reset().Print(" aborted\n")
 		}
 	}
 }

--- a/commands/ps.go
+++ b/commands/ps.go
@@ -33,7 +33,7 @@ func PsAction(c *cli.Context) {
 
 func getPorts(service *services.Service) string {
 	re := regexp.MustCompile("LISTEN")
-	cmd := exec.Command("lsof", "-p", fmt.Sprintf("%d", service.Process.Pid))
+	cmd := exec.Command("lsof", "-P", "-p", fmt.Sprintf("%d", service.Process.Pid))
 	output := bytes.NewBuffer([]byte{})
 	cmd.Stdout = output
 	cmd.Stderr = output

--- a/services/services.go
+++ b/services/services.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -36,6 +37,29 @@ func init() {
 // and starts the service discovery
 func Init() {
 	DiscoverServices()
+}
+
+func Sort(r map[string]*Service) SortableRegistry {
+	sr := make(SortableRegistry, 0)
+	for _, v := range r {
+		sr = append(sr, v)
+	}
+	sort.Sort(sr)
+	return sr
+}
+
+type SortableRegistry []*Service
+
+func (s SortableRegistry) Len() int {
+	return len(s)
+}
+
+func (s SortableRegistry) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s SortableRegistry) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
 }
 
 // Service encapsulates all the information needed for a service

--- a/services/services.go
+++ b/services/services.go
@@ -80,6 +80,7 @@ type Service struct {
 	PackageInfo *build.Package
 	Process     *os.Process
 	Env         []string
+	Ports       string
 }
 
 func (s *Service) IsRunning() bool {


### PR DESCRIPTION
- Sort services alphabetically
- Fix lsof output so it shows port _numbers_ rather than guessing service names, eg. `*:8000/tcp` rather than `*:irdmi/tcp`
