### PR TITLE
Add separate "install" task

### DIFF
--- a/commands/install.go
+++ b/commands/install.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/codegangsta/cli"
+	"github.com/mondough/orchestra/services"
+	"github.com/wsxiaoys/terminal"
+)
+
+var InstallCommand = &cli.Command{
+	Name:         "install",
+	Usage:        "Installs all the services",
+	Action:       BeforeAfterWrapper(InstallAction),
+	BashComplete: ServicesBashComplete}
+
+// InstallAction installs all the services (or the specified ones)
+func InstallAction(c *cli.Context) {
+	worker := func(service *services.Service) func() {
+		return func() {
+			spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
+			rebuilt, err := installService(service)
+			if err != nil {
+				appendError(err)
+				terminal.Stdout.Colorf("%s%s| @{r} error: @{|}%v\n", service.Name, spacing, err)
+			} else if rebuilt {
+				terminal.Stdout.Colorf("%s%s| @{g} installed\n", service.Name, spacing)
+			} else {
+				terminal.Stdout.Colorf("%s%s| @{g} already up to date\n", service.Name, spacing)
+			}
+		}
+	}
+
+	pool := make(workerPool, runtime.NumCPU())
+	for _, service := range FilterServices(c) {
+		pool.Do(worker(service))
+	}
+	pool.Drain()
+}
+
+// installService runs go install in the service directory
+func installService(service *services.Service) (bool, error) {
+	cmd := exec.Command("nice", "-n", niceness, "go", "install", "-v")
+	cmd.Dir = service.Path
+	output := bytes.NewBuffer([]byte{})
+	cmd.Stdout = output
+	cmd.Stderr = output
+	err := cmd.Start()
+	if err != nil {
+		return false, err
+	}
+	cmd.Wait()
+	if !cmd.ProcessState.Success() {
+		return false, fmt.Errorf("Failed to install service %s\n%s", service.Name, output.String())
+	} else if output.Len() > 0 {
+		return true, nil
+	}
+	return false, nil
+}

--- a/commands/start.go
+++ b/commands/start.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -55,7 +54,7 @@ func start(c *cli.Context, service *services.Service) {
 		rebuilt, err := buildAndStart(c, service)
 		if err != nil {
 			appendError(err)
-			terminal.Stdout.Colorf("%s%s| @{r} error: @{|}%s\n", service.Name, spacing, err.Error())
+			terminal.Stdout.Colorf("%s%s| @{r} error: @{|}%v\n", service.Name, spacing, err)
 		} else {
 			var rebuiltStatus string
 			if rebuilt {
@@ -107,24 +106,4 @@ func buildAndStart(c *cli.Context, service *services.Service) (bool, error) {
 		return rebuilt, fmt.Errorf("Service %s exited after %s", cmd.ProcessState.UserTime().String())
 	}
 	return rebuilt, nil
-}
-
-// installService runs go install in the service directory
-func installService(service *services.Service) (bool, error) {
-	cmd := exec.Command("nice", "-n", niceness, "go", "install", "-v")
-	cmd.Dir = service.Path
-	output := bytes.NewBuffer([]byte{})
-	cmd.Stdout = output
-	cmd.Stderr = output
-	err := cmd.Start()
-	if err != nil {
-		return false, err
-	}
-	cmd.Wait()
-	if !cmd.ProcessState.Success() {
-		return false, fmt.Errorf("Failed to install service %s\n%s", service.Name, output.String())
-	} else if output.Len() > 0 {
-		return true, nil
-	}
-	return false, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -31,14 +31,15 @@ type Config struct {
 	GoRun  bool              `gorun,omitempty`
 
 	// Configuration for Commands
+	Build   ContextConfig `build,omitempty`
+	Export  ContextConfig `export,omitempty`
+	Install ContextConfig `install,omitempty`
+	Logs    ContextConfig `logs,omitempty`
+	Ps      ContextConfig `ps,omitempty`
+	Restart ContextConfig `restart,omitempty`
 	Start   ContextConfig `start,omitempty`
 	Stop    ContextConfig `stop,omitempty`
-	Restart ContextConfig `restart,omitempty`
-	Ps      ContextConfig `ps,omitempty`
-	Logs    ContextConfig `logs,omitempty`
 	Test    ContextConfig `test,omitempty`
-	Export  ContextConfig `export,omitempty`
-	Build   ContextConfig `build,omitempty`
 }
 
 func GetBaseEnvVars() map[string]string {

--- a/main.go
+++ b/main.go
@@ -22,18 +22,17 @@ func main() {
 	app = cli.NewApp()
 	app.Name = "Orchestra"
 	app.Usage = "Orchestrate Go Services"
-	app.Author = "Vincenzo Prignano"
-	app.Email = ""
 	app.EnableBashCompletion = true
 	app.Commands = []cli.Command{
+		*commands.BuildCommand,
 		*commands.ExportCommand,
+		*commands.InstallCommand,
+		*commands.LogsCommand,
+		*commands.PsCommand,
+		*commands.RestartCommand,
 		*commands.StartCommand,
 		*commands.StopCommand,
-		*commands.LogsCommand,
-		*commands.RestartCommand,
-		*commands.PsCommand,
 		*commands.TestCommand,
-		*commands.BuildCommand,
 	}
 	app.Flags = []cli.Flag{
 		cli.StringFlag{

--- a/services/services.go
+++ b/services/services.go
@@ -107,8 +107,7 @@ func DiscoverServices() {
 					LogFilePath:   fmt.Sprintf("%s/%s.log", OrchestraServicePath, serviceName),
 					PidFilePath:   fmt.Sprintf("%s/%s.pid", OrchestraServicePath, serviceName),
 					Color:         colors[len(Registry)%len(colors)],
-					Path:          fmt.Sprintf("%s/%s", ProjectPath, serviceName),
-				}
+					Path:          fmt.Sprintf("%s/%s", ProjectPath, serviceName)}
 
 				// Parse env variable in configuration
 				var serviceConfig struct {


### PR DESCRIPTION
As part of testing, I'd like to `go install` all the things before actually starting the services. This avoids services all trying to come up and connect to shared resources at a time when the CPU is already under massive contention.
