### PR TITLE
Fix deprecation warnings from upstream interface change

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -20,7 +20,7 @@ var BuildCommand = &cli.Command{
 	BashComplete: ServicesBashComplete,
 }
 
-func BuildAction(c *cli.Context) {
+func BuildAction(c *cli.Context) error {
 	worker := func(service *services.Service) func() {
 		return func() {
 			buildService(c, service)
@@ -33,6 +33,7 @@ func BuildAction(c *cli.Context) {
 		pool.Do(worker(service))
 	}
 	pool.Drain()
+	return nil
 }
 
 func buildService(c *cli.Context, service *services.Service) {

--- a/commands/export.go
+++ b/commands/export.go
@@ -15,8 +15,9 @@ var ExportCommand = &cli.Command{
 	BashComplete: ServicesBashComplete,
 }
 
-func ExportAction(c *cli.Context) {
+func ExportAction(c *cli.Context) error {
 	for key, value := range config.GetBaseEnvVars() {
 		terminal.Stdout.Print(fmt.Sprintf("export %s=%s\n", key, value))
 	}
+	return nil
 }

--- a/commands/install.go
+++ b/commands/install.go
@@ -19,7 +19,7 @@ var InstallCommand = &cli.Command{
 	BashComplete: ServicesBashComplete}
 
 // InstallAction installs all the services (or the specified ones)
-func InstallAction(c *cli.Context) {
+func InstallAction(c *cli.Context) error {
 	worker := func(service *services.Service) func() {
 		return func() {
 			spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
@@ -40,6 +40,7 @@ func InstallAction(c *cli.Context) {
 		pool.Do(worker(service))
 	}
 	pool.Drain()
+	return nil
 }
 
 // installService runs go install in the service directory

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -25,7 +25,7 @@ func init() {
 	logReceiver = make(chan string)
 }
 
-func LogsAction(c *cli.Context) {
+func LogsAction(c *cli.Context) error {
 	go ConsumeLogs()
 	wg := &sync.WaitGroup{}
 	for _, service := range FilterServices(c) {
@@ -34,6 +34,7 @@ func LogsAction(c *cli.Context) {
 	}
 	wg.Wait()
 	close(logReceiver)
+	return nil
 }
 
 func ConsumeLogs() {

--- a/commands/ps.go
+++ b/commands/ps.go
@@ -21,7 +21,7 @@ var PsCommand = &cli.Command{
 }
 
 // PsAction checks the status for every service and output
-func PsAction(c *cli.Context) {
+func PsAction(c *cli.Context) error {
 	svcs := services.Sort(FilterServices(c))
 
 	var wg sync.WaitGroup
@@ -42,6 +42,7 @@ func PsAction(c *cli.Context) {
 			terminal.Stdout.Colorf("@{r}%s", service.Name).Reset().Colorf("%s|", spacing).Reset().Print(" aborted\n")
 		}
 	}
+	return nil
 }
 
 func getPorts(service *services.Service) string {

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -27,7 +27,7 @@ var RestartCommand = &cli.Command{
 }
 
 // RestartAction restarts all the services (or the specified ones)
-func RestartAction(c *cli.Context) {
+func RestartAction(c *cli.Context) error {
 	worker := func(service *services.Service) func() {
 		return func() {
 			restart(c, service)
@@ -44,6 +44,7 @@ func RestartAction(c *cli.Context) {
 	if c.Bool("attach") || c.Bool("logs") {
 		LogsAction(c)
 	}
+	return nil
 }
 
 func restart(c *cli.Context, service *services.Service) {

--- a/commands/start.go
+++ b/commands/start.go
@@ -33,7 +33,7 @@ var StartCommand = &cli.Command{
 }
 
 // StartAction starts all the services (or the specified ones)
-func StartAction(c *cli.Context) {
+func StartAction(c *cli.Context) error {
 	worker := func(service *services.Service) func() {
 		return func() { start(c, service) }
 	}
@@ -47,6 +47,7 @@ func StartAction(c *cli.Context) {
 	if c.Bool("attach") || c.Bool("logs") {
 		LogsAction(c)
 	}
+	return nil
 }
 
 func start(c *cli.Context, service *services.Service) {

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -17,7 +17,7 @@ var StopCommand = &cli.Command{
 }
 
 // StopAction stops all the services (or the specified ones)
-func StopAction(c *cli.Context) {
+func StopAction(c *cli.Context) error {
 	svcs := services.Sort(FilterServices(c))
 	for _, service := range svcs {
 		spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
@@ -29,6 +29,7 @@ func StopAction(c *cli.Context) {
 			terminal.Stdout.Colorf("%s%s| @{r} stopped\n", service.Name, spacing)
 		}
 	}
+	return nil
 }
 
 func killService(service *services.Service) error {

--- a/commands/test.go
+++ b/commands/test.go
@@ -27,7 +27,7 @@ var TestCommand = &cli.Command{
 }
 
 // StartAction starts all the services (or the specified ones)
-func TestAction(c *cli.Context) {
+func TestAction(c *cli.Context) error {
 	svcs := services.Sort(FilterServices(c))
 	for _, service := range svcs {
 		spacing := strings.Repeat(" ", services.MaxServiceNameLength+2-len(service.Name))
@@ -42,6 +42,7 @@ func TestAction(c *cli.Context) {
 			terminal.Stdout.Colorf("%s%s| @{g} PASS\n", service.Name, spacing)
 		}
 	}
+	return nil
 }
 
 // startService takes a Service struct as input, creates a new log file in .orchestra,

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -65,8 +65,8 @@ func ServicesBashComplete(c *cli.Context) {
 	}
 }
 
-func BeforeAfterWrapper(f func(c *cli.Context)) func(c *cli.Context) {
-	return func(c *cli.Context) {
+func BeforeAfterWrapper(f func(c *cli.Context) error) func(c *cli.Context) error {
+	return func(c *cli.Context) error {
 		err := config.GetBeforeFunc()(c)
 		if err != nil {
 			appendError(err)
@@ -76,6 +76,7 @@ func BeforeAfterWrapper(f func(c *cli.Context)) func(c *cli.Context) {
 		if err != nil {
 			appendError(err)
 		}
+		return nil
 	}
 }
 


### PR DESCRIPTION
Fix deprecation warnings from upstream interface change in CLI package.

`DEPRECATED Action signature.  Must be `cli.ActionFunc`.  This is an error in the application.  Please contact the distributor of this application if this is not you.  See https://github.com/urfave/cli/blob/master/CHANGELOG.md#deprecated-cli-app-action-signature`
